### PR TITLE
Align Desk Tidy with shared course shell

### DIFF
--- a/course-family-navigation.css
+++ b/course-family-navigation.css
@@ -1,0 +1,13 @@
+:root { --hub-ink:#5b3d22; --hub-paper:#fdf9f3; }
+.course-family-nav { background:var(--hub-paper); border-top:2px solid #3c2818; border-bottom:1px solid #eadfce; color:var(--hub-ink); position:relative; width:100%; z-index:1000; }
+.course-family-nav *, .course-family-nav *::before, .course-family-nav *::after { box-sizing:border-box; }
+.course-family-nav__inner { align-items:center; display:flex; gap:1.15rem 2rem; margin:0 auto; max-width:1440px; min-height:82px; padding:.8rem 1.25rem; }
+.course-family-nav__brand { align-items:center; color:var(--hub-ink); display:inline-flex; flex:0 0 auto; font-size:1.05rem; font-weight:850; gap:.7rem; line-height:1.2; text-decoration:none; }
+.course-family-nav__mark { align-items:center; background:#f0c778; border-radius:50%; color:var(--hub-ink); display:inline-flex; font-size:.75rem; font-weight:900; height:42px; justify-content:center; width:42px; }
+.course-family-nav__links { align-items:center; display:flex; flex:1 1 auto; flex-wrap:wrap; gap:.25rem .4rem; }
+.course-family-nav__links a { border-radius:12px; color:var(--hub-ink); display:inline-flex; font-size:1rem; font-weight:760; line-height:1.2; padding:.72rem .78rem; text-decoration:none; white-space:nowrap; }
+.course-family-nav__links a:hover, .course-family-nav__links a:focus-visible { background:#f3ebdf; color:#493018; outline:3px solid #e6dac8; outline-offset:2px; }
+.course-family-nav__links a[aria-current="page"] { background:#eee3d4; }
+.has-course-family-nav .hub-return-bar, .has-course-family-nav .site-header, .has-course-family-nav .course-bar { display:none!important; }
+@media(max-width:780px){.course-family-nav__inner{display:grid;gap:.6rem;min-height:0;padding:.7rem .8rem .55rem}.course-family-nav__mark{height:36px;width:36px}.course-family-nav__links{flex-wrap:nowrap;margin-inline:-.8rem;overflow-x:auto;padding:0 .8rem .45rem;scrollbar-width:thin}.course-family-nav__links a{flex:0 0 auto;font-size:.92rem;padding:.62rem .72rem}}
+@media print {.course-family-nav{display:none!important}}

--- a/index.html
+++ b/index.html
@@ -21,9 +21,8 @@
         <h1>Desk Tidy Guided Course</h1>
         <p class="hero-subtitle">Design an organiser for a real user. Build it safely. Prove every decision.</p>
         <div class="hero-actions">
-          <a class="button-link" href="weeks1-2/index.html">Begin Weeks 1&ndash;2</a>
+          <a class="button-link" href="weeks1-2/index.html">Start Module 1</a>
           <a class="button-link secondary" href="desk-tidy-folio.html">Open Project Folio</a>
-          <a class="button-link secondary" href="Desk-Tidy-Project-Unit.pdf" target="_blank" rel="noopener">Open Plans</a>
         </div>
       </div>
       <figure class="hero-showcase hero-image-contain"><img class="hero-project" src="assets/desk-tidy-reference.png" alt="Timber Desk Tidy with compartments for stationery"></figure>

--- a/shared/hub-navigation.js
+++ b/shared/hub-navigation.js
@@ -1,59 +1,49 @@
 (function () {
   "use strict";
-
-  const HUB_URL = "https://stevencowell.github.io/Main-Page/";
+  if (document.querySelector(".course-family-nav")) return;
   const script = document.currentScript;
-  const stylesheetUrl = script ? new URL("sister-site.css", script.src).href : "";
-  const courseRoot = script ? new URL("../", script.src) : new URL("./", location.href);
-
-  if (stylesheetUrl && !document.querySelector('link[data-sister-site-styles]')) {
+  const root = new URL("../", script && script.src ? script.src : location.href);
+  const stylesheetUrl = new URL("course-family-navigation.css?v=20260814", root).href;
+  if (!document.querySelector("link[data-course-family-nav-styles]")) {
     const stylesheet = document.createElement("link");
     stylesheet.rel = "stylesheet";
     stylesheet.href = stylesheetUrl;
-    stylesheet.dataset.sisterSiteStyles = "";
+    stylesheet.dataset.courseFamilyNavStyles = "";
     document.head.append(stylesheet);
   }
-
-  if (document.querySelector(".course-family-nav")) return;
-
   const path = location.pathname.toLowerCase();
-  const rootPath = courseRoot.pathname.replace(/\/$/, "").toLowerCase();
-  const isCourseHome = path === `${rootPath}/` || path === `${rootPath}/index.html`;
-  const bar = document.createElement("nav");
-  bar.className = "course-family-nav screen-only";
-  bar.setAttribute("aria-label", "Desk Tidy course navigation");
-
+  const rootPath = root.pathname.replace(/\/$/, "").toLowerCase();
+  const isHome = path === `${rootPath}/` || path === `${rootPath}/index.html`;
+  const nav = document.createElement("nav");
+  nav.className = "course-family-nav screen-only";
+  nav.setAttribute("aria-label", "Desk Tidy course navigation");
   const inner = document.createElement("div");
   inner.className = "course-family-nav__inner";
-
   const brand = document.createElement("a");
   brand.className = "course-family-nav__brand";
-  brand.href = new URL("index.html", courseRoot).href;
+  brand.href = new URL("index.html", root).href;
   brand.innerHTML = '<span class="course-family-nav__mark" aria-hidden="true">DT</span><span>Desk Tidy</span>';
-
   const links = document.createElement("div");
   links.className = "course-family-nav__links";
   const items = [
-    { label: "Course", href: "index.html", current: isCourseHome },
-    { label: "Modules", href: "index.html#course-map-title", current: /\/weeks\d+-\d+\//.test(path) || path.includes("/sections/main-theory/") },
-    { label: "Video learning", href: "youtube-library/video-library.html", current: path.includes("/youtube-library/") },
-    { label: "Busy Work", href: "https://stevencowell.github.io/busy-worksheets/?library=timber", external: true },
-    { label: "My folio", href: "desk-tidy-folio.html", current: path.endsWith("/desk-tidy-folio.html") },
-    { label: "Assessment", href: "assessment-pathway-2026.html", current: path.includes("assessment-pathway") || path.includes("/exams/") },
-    { label: "Teacher resources", href: "sections/program.html", current: path.endsWith("/sections/program.html") },
-    { label: "Main Menu", href: HUB_URL, external: true }
+    ["Course", "index.html", isHome],
+    ["Modules", "index.html#course-map-title", /\/weeks\d+-\d+\//.test(path)],
+    ["Video learning", "youtube-library/video-library.html", path.includes("/youtube-library/")],
+    ["Busy Work", "https://stevencowell.github.io/busy-worksheets/?library=timber", false, true],
+    ["My folio", "desk-tidy-folio.html", path.endsWith("/desk-tidy-folio.html")],
+    ["Project unit", "Desk-Tidy-Project-Unit.pdf", false],
+    ["Teacher resources", "teacher-resources.html", path.endsWith("/teacher-resources.html")],
+    ["Main Menu", "https://stevencowell.github.io/Main-Page/", false, true]
   ];
-
-  items.forEach((item) => {
+  items.forEach(([label, href, current, external]) => {
     const link = document.createElement("a");
-    link.href = item.external ? item.href : new URL(item.href, courseRoot).href;
-    link.textContent = item.label;
-    if (item.current) link.setAttribute("aria-current", "page");
+    link.textContent = label;
+    link.href = external ? href : new URL(href, root).href;
+    if (current) link.setAttribute("aria-current", "page");
     links.append(link);
   });
-
   inner.append(brand, links);
-  bar.append(inner);
-  document.body.prepend(bar);
+  nav.append(inner);
+  document.body.prepend(nav);
   document.documentElement.classList.add("has-course-family-nav");
 })();

--- a/teacher-resources.html
+++ b/teacher-resources.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en-AU">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Teacher resources and delivery controls for the Stage 4 Desk Tidy course.">
+  <title>Teacher Resources | Desk Tidy</title>
+  <link rel="stylesheet" href="styles/course.css">
+  <link rel="stylesheet" href="shared/sister-site.css">
+  <link rel="stylesheet" href="course-family-navigation.css?v=20260814" data-course-family-nav-styles>
+  <link rel="stylesheet" href="course-family-hero.css">
+  <script src="shared/hub-navigation.js?v=20260814" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to teacher resources</a>
+  <header class="hero landing-hero sister-hero course-family-hero" style="--hero-start:#5b3d22;--hero-end:#a36c34;--hero-accent:#f0c778">
+    <div class="hero-inner course-family-hero-inner">
+      <div class="hero-copy">
+        <p class="eyebrow">Stage 4 Technology Mandatory</p>
+        <h1>Teacher Resources</h1>
+        <p class="hero-subtitle">Approved project sources, assessment pathway and staff change requests for the Desk Tidy course.</p>
+        <div class="hero-actions">
+          <a class="button-link" href="index.html">Course Home</a>
+          <a class="button-link secondary" href="assessment-pathway-2026.html">Assessment Pathway</a>
+        </div>
+      </div>
+      <figure class="hero-showcase hero-image-contain"><img class="hero-project" src="assets/desk-tidy-reference.png" alt="Timber Desk Tidy with stationery compartments"></figure>
+    </div>
+  </header>
+  <main id="main-content" class="landing-main">
+    <section class="card">
+      <p class="section-kicker">Authoritative project sources</p>
+      <h2>Use the current Stage 4 project unit</h2>
+      <p>The supplied project unit controls the ten-week sequence, assessment weighting, named materials and specified finishing and test requirements. The current NESA syllabus and support document control outcome wording.</p>
+      <div class="resource-actions">
+        <a class="button-link" href="Stage%204%20Technology%20Mandatory%20-%20desk%20tidy%20(1).pdf" target="_blank" rel="noopener">Open Project Unit</a>
+        <a class="button-link secondary" href="SOURCE-NOTES.md" target="_blank" rel="noopener">Open Source Notes</a>
+      </div>
+    </section>
+    <section class="card">
+      <p class="section-kicker">Delivery boundary</p>
+      <h2>Teacher direction controls practical work and submission</h2>
+      <p>Dimensions, stock allocation, tolerances, machine setup, practical permissions, assessment adjustments and submission routes remain teacher controlled. Students must follow the school SOP and SWMS for the actual workshop equipment.</p>
+      <p>Browser storage is a working copy, not a submission system. Students should save module evidence as PDF and use the teacher-provided submission method.</p>
+    </section>
+    <section class="card">
+      <p class="section-kicker">Staff change request</p>
+      <h2>Suggest a change</h2>
+      <p>Report the affected page, the proposed correction and the approved source supporting it.</p>
+      <a class="button-link" href="https://github.com/stevencowell/desk-tidy/issues/new?title=Desk%20Tidy%20course%20change%20request&amp;body=Page%20or%20module%3A%0A%0ASuggested%20change%3A%0A%0AApproved%20source%3A%0A" target="_blank" rel="noopener">Suggest a Change</a>
+    </section>
+  </main>
+  <footer><p>Desk Tidy Teacher Resources</p><p>Wagga Wagga High School | Stage 4 Technology Mandatory</p></footer>
+</body>
+</html>


### PR DESCRIPTION
## What changed
- replaced the old return bar with the shared course navigation
- added Course, Modules, Video learning, Busy Work, My folio, Project unit, Teacher resources and Main Menu
- preserved the five-module sequence, source-backed project image and Stage 4 project authority
- reduced the hero to the standard two student actions
- added a staff-only Teacher Resources page with approved sources, assessment pathway and change-request action

## Checks
- commit-specific RawGitHack preview verified
- original Desk Tidy image remains visible
- no horizontal page overflow
- Teacher resources and staff change request verified
- no browser console errors observed

Draft only; nothing has been merged or pushed live.