### PR TITLE
Standardise module page presentation

### DIFF
--- a/module-standard.css
+++ b/module-standard.css
@@ -1,0 +1,259 @@
+/* TAS module-page visual contract v1
+   Based on the Timber Pen guided lesson pages.
+   This file changes presentation only; course content and behaviour stay local. */
+:root {
+  --tas-brand: #0b5fad;
+  --tas-brand-dark: #073f75;
+  --tas-brand-light: #eaf4ff;
+  --tas-accent: #0d7a68;
+  --tas-accent-light: #e8f7f3;
+  --tas-ink: #182334;
+  --tas-muted: #5a6778;
+  --tas-line: #d9e1ea;
+  --tas-surface: #ffffff;
+  --tas-background: #f3f6f9;
+  --tas-shadow: 0 10px 28px rgba(25, 48, 74, 0.09);
+  --tas-radius: 16px;
+  --tas-page: 1180px;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  color: var(--tas-ink);
+  background: var(--tas-background);
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 17px;
+  line-height: 1.65;
+}
+img { max-width: 100%; }
+a { color: var(--tas-brand); }
+button, input, textarea, select { font: inherit; }
+
+/* Shared course navigation */
+:is(.course-bar, .site-header, .site-return-bar) {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  min-height: 58px;
+  color: var(--tas-brand-dark);
+  background: rgba(255, 255, 255, 0.98);
+  border: 0;
+  border-bottom: 1px solid var(--tas-line);
+  box-shadow: 0 4px 14px rgba(25, 48, 74, 0.07);
+}
+:is(.course-bar-inner, .nav-wrap) {
+  width: min(var(--tas-page), calc(100% - 36px));
+  min-height: 58px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+:is(.course-brand, .brand, .site-return-link) {
+  color: var(--tas-brand-dark);
+  font-weight: 900;
+  text-decoration: none;
+}
+:is(.course-links, .nav-links, .site-nav) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+}
+:is(.course-links, .nav-links, .site-nav) a {
+  color: var(--tas-brand-dark);
+  font-weight: 800;
+  text-decoration: none;
+  padding: 7px 10px;
+  border-radius: 8px;
+}
+:is(.course-links, .nav-links, .site-nav) a:hover,
+:is(.course-links, .nav-links, .site-nav) a:focus-visible,
+:is(.course-links, .nav-links, .site-nav) a.active {
+  color: var(--tas-brand);
+  background: var(--tas-brand-light);
+}
+
+/* Consistent module title banner */
+:is(.lesson-hero, .module-hero, .page-hero) {
+  min-height: 250px;
+  color: #fff;
+  background: linear-gradient(125deg, var(--tas-brand-dark), var(--tas-brand));
+  border: 0;
+  border-bottom: 5px solid #d9a441;
+  box-shadow: none;
+}
+:is(.lesson-hero .hero-inner, .module-hero-inner, .page-hero .wrap, .page-hero > .wrap) {
+  width: min(var(--tas-page), calc(100% - 36px));
+  min-height: 250px;
+  margin: 0 auto;
+  padding: 40px 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+}
+:is(.lesson-hero, .module-hero, .page-hero) :is(h1, h2) {
+  max-width: 900px;
+  margin: 0 0 8px;
+  color: #fff;
+  font-size: clamp(2.4rem, 5vw, 3.8rem);
+  line-height: 1.05;
+  letter-spacing: -0.035em;
+  text-shadow: none;
+}
+:is(.lesson-hero, .module-hero, .page-hero) :is(.eyebrow, .breadcrumbs) {
+  color: #d9edff;
+  font-weight: 800;
+}
+:is(.lesson-hero, .module-hero, .page-hero) :is(p, .lede, .hero-subtitle) {
+  max-width: 780px;
+  margin: 6px 0 0;
+  color: rgba(255, 255, 255, 0.94);
+}
+
+/* Page frame and reading rhythm */
+body > main,
+.module-layout,
+.theory-main {
+  width: min(1120px, calc(100% - 34px));
+  margin: 30px auto 60px;
+}
+.module-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 24px;
+  align-items: start;
+}
+.module-main { min-width: 0; }
+:is(.module-aside, .module-sidebar) {
+  position: sticky;
+  top: 82px;
+}
+
+/* Shared content surfaces */
+:is(.card, .textbook-section, .theory-section, .panel-section, .student-panel, .module-aside, .module-sidebar) {
+  color: var(--tas-ink);
+  background: var(--tas-surface);
+  border: 1px solid var(--tas-line);
+  border-radius: var(--tas-radius);
+  box-shadow: var(--tas-shadow);
+}
+:is(.card, .textbook-section, .theory-section, .panel-section, .student-panel) {
+  padding: clamp(22px, 4vw, 38px);
+  margin-bottom: 22px;
+}
+:is(.module-aside, .module-sidebar) { padding: 20px; }
+:is(.card, .textbook-section, .theory-section, .panel-section, .student-panel) h2 {
+  margin-top: 0;
+  color: var(--tas-brand-dark);
+  font-size: clamp(1.5rem, 2.7vw, 2.05rem);
+  line-height: 1.2;
+}
+:is(.card, .textbook-section, .theory-section, .panel-section, .student-panel) h3 {
+  color: var(--tas-ink);
+  line-height: 1.3;
+}
+:is(.fine, .muted, .module-summary) { color: var(--tas-muted); }
+
+/* Actions and progress */
+:is(.button, .btn, .primary-button, .module-link, button:not(.nav-toggle)) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 10px 16px;
+  color: #fff;
+  background: var(--tas-brand);
+  border: 2px solid var(--tas-brand);
+  border-radius: 10px;
+  font-weight: 800;
+  line-height: 1.25;
+  text-decoration: none;
+  box-shadow: none;
+}
+:is(.button, .btn).secondary,
+.secondary.button {
+  color: var(--tas-brand-dark);
+  background: #fff;
+  border-color: #b9c9d9;
+}
+:is(.button, .btn, .primary-button, .module-link, button:not(.nav-toggle)):hover,
+:is(.button, .btn, .primary-button, .module-link, button:not(.nav-toggle)):focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(0.97);
+}
+.actions { display: flex; flex-wrap: wrap; gap: 10px; }
+:is(.progress-shell, .progress-bar) { border-radius: 999px; }
+.progress-shell { overflow: hidden; background: #dfe7ef; }
+.progress-bar { background: var(--tas-accent); }
+
+/* Common information treatments */
+:is(.callout, .key-idea, .learning-card) {
+  border-radius: 12px;
+  border: 1px solid #bed9ef;
+  background: var(--tas-brand-light);
+}
+table { max-width: 100%; }
+:is(.table-scroll, .theory-table-wrap) { overflow-x: auto; }
+input[type="text"], input[type="email"], textarea, select {
+  max-width: 100%;
+  border: 1px solid #aebccc;
+  border-radius: 9px;
+  padding: 10px 12px;
+  color: var(--tas-ink);
+  background: #fff;
+}
+input:focus, textarea:focus, select:focus {
+  outline: 3px solid rgba(11, 95, 173, 0.18);
+  border-color: var(--tas-brand);
+}
+
+@media (max-width: 840px) {
+  :is(.course-bar-inner, .nav-wrap) {
+    width: min(100% - 24px, var(--tas-page));
+    min-height: 64px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px 0;
+  }
+  :is(.course-links, .nav-links, .site-nav) {
+    width: 100%;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+  :is(.lesson-hero, .module-hero, .page-hero),
+  :is(.lesson-hero .hero-inner, .module-hero-inner, .page-hero .wrap, .page-hero > .wrap) {
+    min-height: 220px;
+  }
+  :is(.lesson-hero .hero-inner, .module-hero-inner, .page-hero .wrap, .page-hero > .wrap) {
+    width: min(100% - 28px, var(--tas-page));
+    padding: 32px 0;
+  }
+  body > main,
+  .module-layout,
+  .theory-main {
+    width: min(100% - 24px, 1120px);
+    margin-top: 20px;
+  }
+  .module-layout { grid-template-columns: 1fr; }
+  :is(.module-aside, .module-sidebar) { position: static; }
+}
+
+@media (max-width: 560px) {
+  body { font-size: 16px; }
+  :is(.lesson-hero, .module-hero, .page-hero) :is(h1, h2) {
+    font-size: clamp(2rem, 11vw, 2.8rem);
+  }
+  :is(.card, .textbook-section, .theory-section, .panel-section, .student-panel) {
+    padding: 20px 17px;
+    border-radius: 13px;
+  }
+  .actions { display: grid; }
+  .actions :is(.button, .btn, .primary-button) { width: 100%; }
+}

--- a/module-standard.css
+++ b/module-standard.css
@@ -42,6 +42,7 @@ button, input, textarea, select { font: inherit; }
   border: 0;
   border-bottom: 1px solid var(--tas-line);
   box-shadow: 0 4px 14px rgba(25, 48, 74, 0.07);
+  padding: 0 !important;
 }
 :is(.course-bar-inner, .nav-wrap) {
   width: min(var(--tas-page), calc(100% - 36px));
@@ -79,12 +80,13 @@ button, input, textarea, select { font: inherit; }
 
 /* Consistent module title banner */
 :is(.lesson-hero, .module-hero, .page-hero) {
-  min-height: 250px;
+  min-height: 250px !important;
   color: #fff;
-  background: linear-gradient(125deg, var(--tas-brand-dark), var(--tas-brand));
+  background: linear-gradient(125deg, var(--tas-brand-dark), var(--tas-brand)) !important;
   border: 0;
   border-bottom: 5px solid #d9a441;
   box-shadow: none;
+  padding: 0 !important;
 }
 :is(.lesson-hero .hero-inner, .module-hero-inner, .page-hero .wrap, .page-hero > .wrap) {
   width: min(var(--tas-page), calc(100% - 36px));
@@ -95,6 +97,7 @@ button, input, textarea, select { font: inherit; }
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
+  max-width: var(--tas-page) !important;
 }
 :is(.lesson-hero, .module-hero, .page-hero) :is(h1, h2) {
   max-width: 900px;
@@ -119,8 +122,9 @@ button, input, textarea, select { font: inherit; }
 body > main,
 .module-layout,
 .theory-main {
-  width: min(1120px, calc(100% - 34px));
-  margin: 30px auto 60px;
+  width: min(1120px, calc(100% - 34px)) !important;
+  max-width: 1120px !important;
+  margin: 30px auto 60px !important;
 }
 .module-layout {
   display: grid;

--- a/weeks1-2/index.html
+++ b/weeks1-2/index.html
@@ -6,6 +6,7 @@
   <meta name="description" content="Desk Tidy guided course for Weeks 1-2: brief, safety and materials.">
   <title>Desk Tidy | Weeks 1-2</title>
   <link rel="stylesheet" href="../styles/course.css?v=20260814c">
+  <link rel="stylesheet" href="../module-standard.css?v=20260814">
 </head>
 <body>
 <a class="skip-link" href="#lesson-content">Skip to lesson</a>

--- a/weeks3-4/index.html
+++ b/weeks3-4/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="icon" href="data:,">
   <meta name="description" content="Desk Tidy guided course for Weeks 3-4: research, concepts and respectful design.">
   <title>Desk Tidy | Weeks 3-4</title><link rel="stylesheet" href="../styles/course.css">
+  <link rel="stylesheet" href="../module-standard.css?v=20260814">
 </head>
 <body>
 <a class="skip-link" href="#lesson-content">Skip to lesson</a>

--- a/weeks5-6/index.html
+++ b/weeks5-6/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en-AU">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="icon" href="data:,"><meta name="description" content="Desk Tidy guided course for Weeks 5-6: Plan before production."><title>Desk Tidy | Weeks 5-6</title><link rel="stylesheet" href="../styles/course.css"></head>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="icon" href="data:,"><meta name="description" content="Desk Tidy guided course for Weeks 5-6: Plan before production."><title>Desk Tidy | Weeks 5-6</title><link rel="stylesheet" href="../styles/course.css">  <link rel="stylesheet" href="../module-standard.css?v=20260814">
+</head>
 <body>
 <a class="skip-link" href="#lesson-content">Skip to lesson</a>
 <header class="course-bar"><div class="course-bar-inner"><a class="course-home" href="../index.html">Desk Tidy Guided Course</a><nav class="course-links" aria-label="Course navigation"><a href="../index.html">Course map</a><a href="../desk-tidy-folio.html">Project folio</a><a href="../Desk-Tidy-Project-Unit.pdf" target="_blank" rel="noopener">Project unit</a></nav></div></header>

--- a/weeks7-8/index.html
+++ b/weeks7-8/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en-AU">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="icon" href="data:,"><meta name="description" content="Desk Tidy guided course for Weeks 7-8: Produce and assemble safely."><title>Desk Tidy | Weeks 7-8</title><link rel="stylesheet" href="../styles/course.css"></head>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="icon" href="data:,"><meta name="description" content="Desk Tidy guided course for Weeks 7-8: Produce and assemble safely."><title>Desk Tidy | Weeks 7-8</title><link rel="stylesheet" href="../styles/course.css">  <link rel="stylesheet" href="../module-standard.css?v=20260814">
+</head>
 <body>
 <a class="skip-link" href="#lesson-content">Skip to lesson</a>
 <header class="course-bar"><div class="course-bar-inner"><a class="course-home" href="../index.html">Desk Tidy Guided Course</a><nav class="course-links" aria-label="Course navigation"><a href="../index.html">Course map</a><a href="../desk-tidy-folio.html">Project folio</a><a href="../Desk-Tidy-Project-Unit.pdf" target="_blank" rel="noopener">Project unit</a></nav></div></header>

--- a/weeks9-10/index.html
+++ b/weeks9-10/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en-AU">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="icon" href="data:,"><meta name="description" content="Desk Tidy guided course for Weeks 9-10: Finish, test and evaluate."><title>Desk Tidy | Weeks 9-10</title><link rel="stylesheet" href="../styles/course.css"></head>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="icon" href="data:,"><meta name="description" content="Desk Tidy guided course for Weeks 9-10: Finish, test and evaluate."><title>Desk Tidy | Weeks 9-10</title><link rel="stylesheet" href="../styles/course.css">  <link rel="stylesheet" href="../module-standard.css?v=20260814">
+</head>
 <body>
 <a class="skip-link" href="#lesson-content">Skip to lesson</a>
 <header class="course-bar"><div class="course-bar-inner"><a class="course-home" href="../index.html">Desk Tidy Guided Course</a><nav class="course-links" aria-label="Course navigation"><a href="../index.html">Course map</a><a href="../desk-tidy-folio.html">Project folio</a><a href="../Desk-Tidy-Project-Unit.pdf" target="_blank" rel="noopener">Project unit</a></nav></div></header>


### PR DESCRIPTION
Applies the shared Timber Pen-based module-page visual contract while preserving all course content, links, scripts and student-work behaviour. This pilot covers only module entry pages; the course front page is unchanged.